### PR TITLE
Deprecate pc_status and introduce preferred cb_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2026-07-15
+
+### Added
+
+- `response['headers']['cb_status']` as the preferred Crawlbase status field.
+- The library resolves status by preferring `cb_status` from the API response (header or JSON body), then falling back to `pc_status` when `cb_status` is absent.
+
+### Deprecated
+
+- `response['headers']['pc_status']` is deprecated but still supported temporarily for backward compatibility. It is populated with the same resolved value as `cb_status`.
+
+### Migration
+
+```python
+# Deprecated (still works temporarily)
+print(response['headers']['pc_status'])
+
+# Preferred
+print(response['headers']['cb_status'])
+```
+
+[1.1.0]: https://github.com/crawlbase-source/crawlbase-python/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -276,4 +276,4 @@ Timeout is in seconds.
 
 ---
 
-Copyright 2025 Crawlbase
+Copyright 2026 Crawlbase

--- a/README.md
+++ b/README.md
@@ -101,12 +101,26 @@ if response['status_code'] == 200:
 
 ## Original status
 
-You can always get the original status and crawlbase status from the response. Read the [Crawlbase documentation](https://crawlbase.com/docs) to learn more about those status.
+You can always get the original status and Crawlbase status from the response. Read the [Crawlbase documentation](https://crawlbase.com/docs) to learn more about those status.
+
+`cb_status` is the preferred Crawlbase status field. The library reads `cb_status` from the API when present, and falls back to `pc_status` otherwise. Both keys are set on `response['headers']` to the resolved value.
 
 ```python
 response = api.get('https://craiglist.com')
 print(response['headers']['original_status'])
+print(response['headers']['cb_status'])
+```
+
+### Migration from `pc_status`
+
+`pc_status` is deprecated but still supported temporarily for backward compatibility. Prefer `cb_status` in new code:
+
+```python
+# Deprecated (still works temporarily)
 print(response['headers']['pc_status'])
+
+# Preferred
+print(response['headers']['cb_status'])
 ```
 
 If you have questions or need help using the library, please open an issue or [contact us](https://crawlbase.com/contact).
@@ -191,7 +205,7 @@ Pass the [url](https://crawlbase.com/docs/storage-api/parameters/#url) that you 
 response = storage_api.get('https://www.apple.com')
 if response['status_code'] == 200:
     print(response['headers']['original_status'])
-    print(response['headers']['pc_status'])
+    print(response['headers']['cb_status'])
     print(response['headers']['url'])
     print(response['headers']['rid'])
     print(response['headers']['stored_at'])
@@ -204,7 +218,7 @@ or you can use the [RID](https://crawlbase.com/docs/storage-api/parameters/#rid)
 response = storage_api.get('RID_REPLACE')
 if response['status_code'] == 200:
     print(response['headers']['original_status'])
-    print(response['headers']['pc_status'])
+    print(response['headers']['cb_status'])
     print(response['headers']['url'])
     print(response['headers']['rid'])
     print(response['headers']['stored_at'])
@@ -233,7 +247,8 @@ response = storage_api.bulk(['RID1', 'RID2', 'RID3', ...])
 if response['status_code'] == 200:
     for item in response['json']:
         print(item['original_status'])
-        print(item['pc_status'])
+        # Bulk items use API payload keys; prefer cb_status, fall back to pc_status
+        print(item.get('cb_status', item.get('pc_status')))
         print(item['url'])
         print(item['rid'])
         print(item['stored_at'])

--- a/crawlbase/base_api.py
+++ b/crawlbase/base_api.py
@@ -89,11 +89,25 @@ class BaseAPI(object):
 
         return body_gzip.read()
 
+    def _resolve_status(self, source):
+        """Prefer cb_status, fall back to deprecated pc_status."""
+        if 'cb_status' in source:
+            return source.get('cb_status')
+        if 'pc_status' in source:
+            return source.get('pc_status')
+        return None
+
+    def _set_status_headers(self, resolved):
+        # cb_status is preferred; pc_status is deprecated but kept for compatibility.
+        status = str(resolved)
+        self.response['headers']['cb_status'] = status
+        self.response['headers']['pc_status'] = status
+
     def parseJsonResponse(self):
         parsed_json = json.loads(self.response['body'])
         if 'original_status' in parsed_json:
             self.response['headers']['original_status'] = str(parsed_json['original_status'])
-            self.response['headers']['pc_status'] = str(parsed_json['pc_status'])
+            self._set_status_headers(self._resolve_status(parsed_json))
             self.response['headers']['url'] = str(parsed_json['url'])
 
         if 'body' in parsed_json:
@@ -111,5 +125,5 @@ class BaseAPI(object):
     def parseRegularResponse(self, handler):
         headers = handler.headers
         self.response['headers']['original_status'] = str(headers.get('original_status'))
-        self.response['headers']['pc_status'] = str(headers.get('pc_status'))
+        self._set_status_headers(self._resolve_status(headers))
         self.response['headers']['url'] = str(headers.get('url'))

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ readme = open('README.md').read()
 setup(
     name = 'crawlbase',
     license = 'Apache-2.0',
-    version = '1.0.0',
+    version = '1.1.0',
     description = 'A Python class that acts as wrapper for Crawlbase scraping and crawling API',
     long_description = readme,
     long_description_content_type = 'text/markdown',

--- a/tests/test_status_headers.py
+++ b/tests/test_status_headers.py
@@ -1,0 +1,136 @@
+import json
+import unittest
+
+from crawlbase.base_api import BaseAPI
+
+
+class FakeHeaders(dict):
+    """Minimal header map supporting both `in` and `.get` like HTTPMessage."""
+
+    def get(self, key, default=None):
+        if key in self:
+            return self[key]
+        return default
+
+
+class FakeHandler(object):
+    def __init__(self, headers):
+        self.headers = headers
+
+
+class BaseAPIStatusTestCase(unittest.TestCase):
+    def setUp(self):
+        self.api = BaseAPI({'token': 'test-token'})
+        self.api.response = {'headers': {}, 'body': ''}
+
+    def _parse_regular(self, headers):
+        self.api.response = {'headers': {}, 'body': ''}
+        self.api.parseRegularResponse(FakeHandler(FakeHeaders(headers)))
+        return self.api.response['headers']
+
+    def _parse_json(self, payload):
+        self.api.response = {
+            'headers': {},
+            'body': json.dumps(payload),
+        }
+        self.api.parseJsonResponse()
+        return self.api.response['headers']
+
+    def test_resolve_only_cb_status(self):
+        self.assertEqual(self.api._resolve_status({'cb_status': '200'}), '200')
+
+    def test_resolve_only_pc_status(self):
+        self.assertEqual(self.api._resolve_status({'pc_status': '200'}), '200')
+
+    def test_resolve_both_prefers_cb_status(self):
+        self.assertEqual(
+            self.api._resolve_status({'cb_status': '200', 'pc_status': '503'}),
+            '200',
+        )
+
+    def test_resolve_neither(self):
+        self.assertIsNone(self.api._resolve_status({}))
+
+    def test_resolve_empty_string_does_not_fall_back(self):
+        self.assertEqual(
+            self.api._resolve_status({'cb_status': '', 'pc_status': '200'}),
+            '',
+        )
+
+    def test_regular_only_cb_status(self):
+        headers = self._parse_regular({'cb_status': '200', 'original_status': '200', 'url': 'https://example.com'})
+        self.assertEqual(headers['cb_status'], '200')
+        self.assertEqual(headers['pc_status'], '200')
+
+    def test_regular_only_pc_status(self):
+        headers = self._parse_regular({'pc_status': '200', 'original_status': '200', 'url': 'https://example.com'})
+        self.assertEqual(headers['cb_status'], '200')
+        self.assertEqual(headers['pc_status'], '200')
+
+    def test_regular_both_prefers_cb_status(self):
+        headers = self._parse_regular({
+            'cb_status': '200',
+            'pc_status': '503',
+            'original_status': '200',
+            'url': 'https://example.com',
+        })
+        self.assertEqual(headers['cb_status'], '200')
+        self.assertEqual(headers['pc_status'], '200')
+
+    def test_regular_neither_status_header(self):
+        headers = self._parse_regular({'original_status': '200', 'url': 'https://example.com'})
+        self.assertEqual(headers['cb_status'], 'None')
+        self.assertEqual(headers['pc_status'], 'None')
+
+    def test_json_only_cb_status(self):
+        headers = self._parse_json({
+            'original_status': '200',
+            'cb_status': '200',
+            'url': 'https://example.com',
+            'body': '<html></html>',
+        })
+        self.assertEqual(headers['cb_status'], '200')
+        self.assertEqual(headers['pc_status'], '200')
+
+    def test_json_only_pc_status(self):
+        headers = self._parse_json({
+            'original_status': '200',
+            'pc_status': '200',
+            'url': 'https://example.com',
+            'body': '<html></html>',
+        })
+        self.assertEqual(headers['cb_status'], '200')
+        self.assertEqual(headers['pc_status'], '200')
+
+    def test_json_both_prefers_cb_status(self):
+        headers = self._parse_json({
+            'original_status': '200',
+            'cb_status': '200',
+            'pc_status': '503',
+            'url': 'https://example.com',
+            'body': '<html></html>',
+        })
+        self.assertEqual(headers['cb_status'], '200')
+        self.assertEqual(headers['pc_status'], '200')
+
+    def test_json_neither_status_field(self):
+        headers = self._parse_json({
+            'original_status': '200',
+            'url': 'https://example.com',
+            'body': '<html></html>',
+        })
+        self.assertEqual(headers['cb_status'], 'None')
+        self.assertEqual(headers['pc_status'], 'None')
+
+    def test_existing_pc_status_access_still_works(self):
+        for headers in (
+            self._parse_regular({'cb_status': '201'}),
+            self._parse_regular({'pc_status': '202'}),
+            self._parse_regular({'cb_status': '200', 'pc_status': '503'}),
+        ):
+            self.assertIn('pc_status', headers)
+            self.assertTrue(headers['pc_status'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Introduce `cb_status` as the preferred Crawlbase status field on `response['headers']`.
- Keep `pc_status` as a deprecated but fully supported alias during the transition (dual-written with the same resolved value).
- Resolve API status by preferring `cb_status`, then falling back to `pc_status` when `cb_status` is absent (HTTP headers and JSON body).
- Document the change in `README.md` and `CHANGELOG.md`, and bump the library version to `1.1.0` (minor, backward-compatible).

## Motivation

The Crawlbase API is moving from the legacy `pc_status` header/field toward `cb_status`. Library consumers should adopt the new name without breaking existing integrations that still read `pc_status`.

## Behavior

| API response | Library exposes |
|---|---|
| Only `cb_status` | `cb_status` and `pc_status` set to that value |
| Only `pc_status` | `cb_status` and `pc_status` set to that value |
| Both present | Both keys use `cb_status` (takes priority) |
| Neither present | Both keys follow existing missing-header behavior (`"None"`) |

## Migration

```python
# Deprecated (still works temporarily)
print(response['headers']['pc_status'])

# Preferred
print(response['headers']['cb_status'])
```

`pc_status` is **not** removed in this release. Removal is reserved for a future major version.

## Test plan

- [x] Unit tests for only `cb_status`
- [x] Unit tests for only `pc_status`
- [x] Unit tests for both present (`cb_status` wins)
- [x] Unit tests for neither present
- [x] Unit tests for JSON body and regular HTTP header sources
- [x] Confirm existing `response['headers']['pc_status']` access still works
- [ ] Run: `python -m unittest discover -s tests -v`
